### PR TITLE
add path-prefix flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ var (
 	ListenAddress        string
 	SubKey               string
 	ChannelServerVersion string
+	PathPrefix           string
 )
 
 func main() {
@@ -58,6 +59,12 @@ func main() {
 			EnvVar:      "CHANNEL_SERVER_VERSION",
 			Destination: &ChannelServerVersion,
 		},
+		cli.StringFlag{
+			Name:        "path-prefix",
+			EnvVar:      "PATH_PREFIX",
+			Value:       "v1-release",
+			Destination: &PathPrefix,
+		},
 	}
 	app.Action = run
 
@@ -80,5 +87,5 @@ func run(c *cli.Context) error {
 		return err
 	}
 
-	return server.ListenAndServe(ctx, ListenAddress, config)
+	return server.ListenAndServe(ctx, ListenAddress, config, PathPrefix)
 }


### PR DESCRIPTION
this pr adds a `--path-prefix` flag so we can access multiple channels with different config-keys assigned to different listening addresses.
part of https://github.com/rancher/rke2/issues/42
example : 
`--path-prefix=v1-k3s-release --listen-address=0.0.0.0:8080` should expose the releases at https://localhost:8080/v1-k3s-release/releases
default is https://localhost:8080/v1-release/releases , the same applies to channels,schemas and  apiRoots 