### PR TITLE
remove the extra yaml.Unmarshal which might cause issues

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -638,7 +638,6 @@ golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjs
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=

--- a/pkg/config/get.go
+++ b/pkg/config/get.go
@@ -91,10 +91,6 @@ func GetReleasesConfig(content []byte, channelServerVersion, subKey string) (*mo
 		}
 	}
 
-	if err := yaml.Unmarshal(content, &allReleases); err != nil {
-		return nil, err
-	}
-
 	// no server version specified, show all releases
 	if channelServerVersion == "" {
 		return &allReleases, nil


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/35073

Re-unmarshaling data to `allReleases` is unnecessary:
- when subKey == "", the same unmarshaling happens twice 
- when subKey != "",  `allReleases` is already the valid data, so there is no need to unmarshaling again 