### PR TITLE
Use an http.Client with a sensible timeout 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -124,68 +124,6 @@ volumes:
 
 ---
 kind: pipeline
-name: arm
-
-platform:
-  os: linux
-  arch: arm
-
-steps:
-- name: build
-  image: rancher/dapper:v0.6.0
-  commands:
-  - dapper ci
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-
-- name: github_binary_release
-  image: plugins/github-release
-  settings:
-    api_key:
-      from_secret: github_token
-    prerelease: true
-    checksum:
-    - sha256
-    checksum_file: CHECKSUMsum-arm.txt
-    checksum_flatten: true
-    files:
-    - "dist/artifacts/*"
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
-- name: docker-publish
-  image: plugins/docker
-  settings:
-    dockerfile: package/Dockerfile
-    password:
-      from_secret: docker_password
-    repo: "rancher/channelserver"
-    tag: "${DRONE_TAG}-arm"
-    username:
-      from_secret: docker_username
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
-volumes:
-- name: docker
-  host:
-    path: /var/run/docker.sock
-
----
-kind: pipeline
 name: manifest
 
 platform:
@@ -203,7 +141,6 @@ steps:
     platforms:
       - linux/amd64
       - linux/arm64
-      - linux/arm
     target: "rancher/channelserver:${DRONE_TAG}"
     template: "rancher/channelserver:${DRONE_TAG}-ARCH"
   when:
@@ -218,7 +155,6 @@ steps:
 depends_on:
 - amd64
 - arm64
-- arm
 
 ---
 

--- a/pkg/config/get.go
+++ b/pkg/config/get.go
@@ -6,12 +6,19 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/blang/semver"
 	"github.com/google/go-github/v29/github"
 	"github.com/rancher/channelserver/pkg/model"
 	"github.com/rancher/wrangler/pkg/data/convert"
 	"sigs.k8s.io/yaml"
+)
+
+var (
+	httpClient = &http.Client{
+		Timeout: time.Second * 5,
+	}
 )
 
 func getURLs(ctx context.Context, urls ...Source) ([]byte, int, error) {
@@ -42,7 +49,7 @@ func get(ctx context.Context, url Source) ([]byte, error) {
 		return nil, err
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/40416


This PR does the following:
1. Cherry pick the changes from https://github.com/rancher/channelserver/pull/18, which has been approved 
2. Fix the CI failure by dropping the build on the Linux/arm platform which is not supported anymore 

