### PR TITLE
Return correct plural type for collections

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -14,8 +14,8 @@ import (
 	"github.com/rancher/apiserver/pkg/types"
 	"github.com/rancher/channelserver/pkg/config"
 	"github.com/rancher/channelserver/pkg/model"
-	"github.com/rancher/channelserver/pkg/server/store"
 	"github.com/rancher/channelserver/pkg/server/store/appdefault"
+	"github.com/rancher/channelserver/pkg/server/store/channel"
 	"github.com/rancher/channelserver/pkg/server/store/release"
 )
 
@@ -39,7 +39,7 @@ func NewHandler(configs map[string]*config.Config) http.Handler {
 	for prefix, config := range configs {
 		server := server.DefaultAPIServer()
 		server.Schemas.MustImportAndCustomize(model.Channel{}, func(schema *types.APISchema) {
-			schema.Store = store.New(config)
+			schema.Store = channel.New(config)
 			schema.CollectionMethods = []string{http.MethodGet}
 			schema.ResourceMethods = []string{http.MethodGet}
 		})

--- a/pkg/server/store/appdefault/store.go
+++ b/pkg/server/store/appdefault/store.go
@@ -17,7 +17,8 @@ func New(config *config.Config) *Store {
 	}
 }
 
-func (c *Store) List(_ *types.APIRequest, _ *types.APISchema) (types.APIObjectList, error) {
+func (c *Store) List(req *types.APIRequest, _ *types.APISchema) (types.APIObjectList, error) {
+	req.Type = "appdefaults"
 	resp := types.APIObjectList{}
 	for _, appDefault := range c.config.AppDefaultsConfig().AppDefaults {
 		resp.Objects = append(resp.Objects, types.APIObject{

--- a/pkg/server/store/channel/store.go
+++ b/pkg/server/store/channel/store.go
@@ -1,4 +1,4 @@
-package store
+package channel
 
 import (
 	"net/http"
@@ -9,18 +9,19 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/schemas/validation"
 )
 
-type ChannelStore struct {
+type Channel struct {
 	empty.Store
 	config *config.Config
 }
 
-func New(config *config.Config) *ChannelStore {
-	return &ChannelStore{
+func New(config *config.Config) *Channel {
+	return &Channel{
 		config: config,
 	}
 }
 
-func (c *ChannelStore) List(_ *types.APIRequest, _ *types.APISchema) (types.APIObjectList, error) {
+func (c *Channel) List(req *types.APIRequest, _ *types.APISchema) (types.APIObjectList, error) {
+	req.Type = "channels"
 	resp := types.APIObjectList{}
 	for _, channel := range c.config.ChannelsConfig().Channels {
 		resp.Objects = append(resp.Objects, types.APIObject{
@@ -32,7 +33,7 @@ func (c *ChannelStore) List(_ *types.APIRequest, _ *types.APISchema) (types.APIO
 	return resp, nil
 }
 
-func (c *ChannelStore) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+func (c *Channel) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
 	redirect, err := c.config.Redirect(id)
 	if err != nil {
 		return types.APIObject{}, nil

--- a/pkg/server/store/release/store.go
+++ b/pkg/server/store/release/store.go
@@ -17,7 +17,8 @@ func New(config *config.Config) *Store {
 	}
 }
 
-func (c *Store) List(_ *types.APIRequest, _ *types.APISchema) (types.APIObjectList, error) {
+func (c *Store) List(req *types.APIRequest, _ *types.APISchema) (types.APIObjectList, error) {
+	req.Type = "releases"
 	resp := types.APIObjectList{}
 	for _, release := range c.config.ReleasesConfig().Releases {
 		resp.Objects = append(resp.Objects, types.APIObject{


### PR DESCRIPTION
Rancher Desktop and other projects were relying on the collection type to be plural: https://github.com/k3s-io/k3s/issues/11447

Ref:
* https://github.com/rancher/channelserver/commit/4e582e2bb58527a24f35e7abf64227c991c30e13
* https://github.com/rancher/apiserver/commit/10457317eb0b218028af5ac2b2d93ab6757e45ce