### PR TITLE
Synchronous config refresh

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,7 +15,7 @@ import (
 
 type Config struct {
 	sync.Mutex
-	loadMutex sync.Mutex
+	refreshMu sync.Mutex
 
 	subKey               string
 	channelServerVersion string
@@ -94,11 +94,11 @@ func NewConfig(ctx context.Context, subKey string, wait Wait, channelServerVersi
 }
 
 func (c *Config) LoadConfig(ctx context.Context) error {
-	locked := c.loadMutex.TryLock()
+	locked := c.refreshMu.TryLock()
 	if !locked {
 		return errors.New("configuration is already being loaded")
 	}
-	defer c.loadMutex.Unlock()
+	defer c.refreshMu.Unlock()
 
 	content, index, err := getURLs(ctx, c.urls...)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -101,22 +101,22 @@ func (c *Config) LoadConfig(ctx context.Context) error {
 
 	content, index, err := getURLs(ctx, c.urls...)
 	if err != nil {
-		return fmt.Errorf("failed to get content from url %s: %v", c.urls[index].URL(), err)
+		return fmt.Errorf("failed to get content from url %s: %w", c.urls[index].URL(), err)
 	}
 
 	config, err := GetChannelsConfig(ctx, content, c.subKey)
 	if err != nil {
-		return fmt.Errorf("failed to get channel config: %v", err)
+		return fmt.Errorf("failed to get channel config: %w", err)
 	}
 
 	releases, err := GetReleasesConfig(content, c.channelServerVersion, c.subKey)
 	if err != nil {
-		return fmt.Errorf("failed to get release config: %v", err)
+		return fmt.Errorf("failed to get release config: %w", err)
 	}
 
 	appDefaultsConfig, err := GetAppDefaultsConfig(content, c.subKey, c.appName)
 	if err != nil {
-		return fmt.Errorf("failed to get app default config: %v", err)
+		return fmt.Errorf("failed to get app default config: %w", err)
 	}
 
 	err = c.setConfig(ctx, c.channelServerVersion, config, releases, appDefaultsConfig)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,6 +93,8 @@ func NewConfig(ctx context.Context, subKey string, wait Wait, channelServerVersi
 	return c
 }
 
+// Reload the configuration from the source urls. Concurrent loads will
+// not block and immediately return an error.
 func (c *Config) LoadConfig(ctx context.Context) error {
 	locked := c.refreshMu.TryLock()
 	if !locked {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -74,9 +74,9 @@ func NewConfig(ctx context.Context, subKey string, wait Wait, channelServerVersi
 	logrus.Infof("Loading configuration from %v", urls)
 	if err := c.LoadConfig(ctx); err != nil {
 		logrus.Fatalf("Failed to load initial config for %s: %v", subKey, err)
-	} else {
-		logrus.Infof("Loaded initial configuration for %s", subKey)
 	}
+
+	logrus.Infof("Loaded initial configuration for %s", subKey)
 
 	if wait != nil {
 		go func() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"sync"
@@ -95,7 +96,7 @@ func NewConfig(ctx context.Context, subKey string, wait Wait, channelServerVersi
 func (c *Config) LoadConfig(ctx context.Context) error {
 	locked := c.loadMutex.TryLock()
 	if !locked {
-		return fmt.Errorf("configuration is already being loaded")
+		return errors.New("configuration is already being loaded")
 	}
 	defer c.loadMutex.Unlock()
 


### PR DESCRIPTION
Rancher uses channelserver as a library to fetch KDM. It would be useful for Rancher if it could know when a refresh completed.

Currently, channelserver doesn't expose any way to know this, only to trigger refreshes (through [`Wait`](https://github.com/rancher/channelserver/blob/v0.9.0/pkg/config/config.go#L27)).

This PR proposes a public function to allow synchronous refreshes.

Potentially needed for https://github.com/rancher/rancher/issues/53204