### PR TITLE
Constructor without initial load

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,6 +93,22 @@ func NewConfig(ctx context.Context, subKey string, wait Wait, channelServerVersi
 	return c
 }
 
+func NewConfigNoLoad(ctx context.Context, subKey string, channelServerVersion string, appName string, ghToken string, urls []Source) *Config {
+	c := &Config{
+		subKey:               subKey,
+		channelServerVersion: channelServerVersion,
+		appName:              appName,
+		urls:                 urls,
+
+		ghToken:           ghToken,
+		channelsConfig:    &model.ChannelsConfig{},
+		releasesConfig:    &model.ReleasesConfig{},
+		appDefaultsConfig: &model.AppDefaultsConfig{},
+	}
+
+	return c
+}
+
 // Reload the configuration from the source urls. Concurrent loads will
 // not block and immediately return an error.
 func (c *Config) LoadConfig(ctx context.Context) error {


### PR DESCRIPTION
Add a new constructor that doesn't try load any data: all loading is up to the user. It also won't self-terminate with `logger.Fatalf` on a failed initial load since there isn't one, this is useful for Rancher which uses channelserver as a library.