### PR TITLE
Add scheduled reloading, livez handler, fatal-on-error

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -44,6 +44,6 @@ k3s:
         - appVersion: '1.2.x'
           defaultVersion: '1.19.5'
   github:
-    owner: rancher
+    owner: k3s-io
     repo: k3s
-  redirectBase: https://github.com/rancher/k3s/releases/tag/
+  redirectBase: https://github.com/k3s-io/k3s/releases/tag/

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/apiserver v0.9.5
 	github.com/rancher/wrangler/v3 v3.7.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/sirupsen/logrus v1.9.4
 	github.com/urfave/cli/v2 v2.4.0
 	sigs.k8s.io/yaml v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/rancher/apiserver v0.9.5 h1:wha4ksQHZKIPcDdXLTy/tGxWzB/l91hUK+cZAHjiM
 github.com/rancher/apiserver v0.9.5/go.mod h1:NLkaZ69HiT6/5OcXm2EZcydCv8PKRcIXaIphABvhX1I=
 github.com/rancher/wrangler/v3 v3.7.0 h1:rB6GJpnc4Kz8lWuAH3wZwQPgJqPGOu43Aih6147uZB8=
 github.com/rancher/wrangler/v3 v3.7.0/go.mod h1:kqldrBWdHR5zIipX/nr8yuZBFqFrL7GfVP1uwVJSWPQ=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=

--- a/main.go
+++ b/main.go
@@ -3,38 +3,43 @@ package main
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rancher/channelserver/pkg/config"
 	"github.com/rancher/channelserver/pkg/server"
+	"github.com/rancher/channelserver/pkg/wait"
 	"github.com/rancher/wrangler/v3/pkg/signals"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 
 var (
-	Version              = "v0.0.0-dev"
-	GitCommit            = "HEAD"
-	URLs                 = cli.NewStringSlice("channels.yaml")
+	Version   = "v0.0.0-dev"
+	GitCommit = "HEAD"
+
+	Debug                bool
+	RefreshFatal         bool
 	RefreshInterval      string
-	ListenAddress        string
-	SubKeys              cli.StringSlice
+	RefreshSchedule      string
 	ChannelServerVersion string
-	PathPrefix           cli.StringSlice
+	ListenAddress        string
 	AppName              string
 	GithubToken          string
+	URLs                 cli.StringSlice
+	SubKeys              cli.StringSlice
+	PathPrefix           cli.StringSlice
 )
 
 func main() {
 	app := cli.NewApp()
-	app.Name = "Channel Server"
+	app.Name = "channelserver"
 	app.Version = fmt.Sprintf("%s (%s)", Version, GitCommit)
 	app.Flags = []cli.Flag{
 		&cli.StringSliceFlag{
-			Name:    "url",
-			EnvVars: []string{"URL"},
-			Value:   URLs,
+			Name:        "url",
+			EnvVars:     []string{"URL"},
+			Value:       cli.NewStringSlice("channels.yaml"),
+			Destination: &URLs,
 		},
 		&cli.StringSliceFlag{
 			Name:        "config-key",
@@ -44,9 +49,22 @@ func main() {
 		},
 		&cli.StringFlag{
 			Name:        "refresh-interval",
+			Usage:       "Time interval between attempted refreshes of the config URL",
 			EnvVars:     []string{"REFRESH_INTERVAL"},
 			Value:       "15m",
 			Destination: &RefreshInterval,
+		},
+		&cli.StringFlag{
+			Name:        "refresh-schedule",
+			Usage:       "Cron expression for attempted refreshes of the config URL; overrides refresh-interval if set",
+			EnvVars:     []string{"REFRESH_SCHEDULE"},
+			Destination: &RefreshSchedule,
+		},
+		&cli.BoolFlag{
+			Name:        "refresh-fatal",
+			Usage:       "Exit with a fatal error if config URL refresh fails",
+			EnvVars:     []string{"REFRESH_FATAL"},
+			Destination: &RefreshFatal,
 		},
 		&cli.StringFlag{
 			Name:        "listen-address",
@@ -61,7 +79,7 @@ func main() {
 		},
 		&cli.StringFlag{
 			Name:        "app-name",
-			Usage:       "the app for which to retrieve the app default versions",
+			Usage:       "Name of the app for which to retrieve the app default versions",
 			EnvVars:     []string{"APP_NAME"},
 			Destination: &AppName,
 		},
@@ -76,37 +94,52 @@ func main() {
 			EnvVars:     []string{"GITHUB_TOKEN"},
 			Destination: &GithubToken,
 		},
+		&cli.BoolFlag{
+			Name:        "debug",
+			EnvVars:     []string{"DEBUG"},
+			Destination: &Debug,
+		},
 	}
 	app.Action = run
 
 	if err := app.Run(os.Args); err != nil {
-		logrus.Fatal(err)
+		logrus.Fatalf("%s error: %v", app.Name, err)
 	}
 }
 
 func run(c *cli.Context) error {
-	logrus.SetOutput(os.Stderr)
-	ctx := signals.SetupSignalContext()
-
-	intval, err := time.ParseDuration(RefreshInterval)
-	if err != nil {
-		return errors.Wrapf(err, "failed to parse %s", RefreshInterval)
-	}
-	if len(SubKeys.Value()) != len(PathPrefix.Value()) {
-		return errors.Errorf("keys-prefix lengths are not equal %s %s %s ", PathPrefix.Value(), SubKeys.Value(), ListenAddress)
-	}
-
 	var (
 		configs = map[string]*config.Config{}
 		sources []config.Source
+		waiter  wait.Wait
+		err     error
 	)
+
+	logrus.SetOutput(os.Stderr)
+	ctx := signals.SetupSignalContext()
+	if Debug {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+
+	if RefreshSchedule != "" {
+		waiter, err = wait.NewSchedule(RefreshSchedule)
+	} else {
+		waiter, err = wait.NewInterval(RefreshInterval)
+	}
+	if err != nil {
+		return err
+	}
+
+	if len(SubKeys.Value()) != len(PathPrefix.Value()) {
+		return errors.Errorf("keys-prefix lengths are not equal %s %s %s", PathPrefix.Value(), SubKeys.Value(), ListenAddress)
+	}
 
 	for _, url := range URLs.Value() {
 		sources = append(sources, config.StringSource(url))
 	}
 	for index, subkey := range SubKeys.Value() {
 		prefix := PathPrefix.Value()[index]
-		config := config.NewConfig(ctx, subkey, &config.DurationWait{Duration: intval}, ChannelServerVersion, AppName, GithubToken, sources)
+		config := config.NewConfig(ctx, subkey, waiter, ChannelServerVersion, AppName, GithubToken, sources, RefreshFatal)
 		configs[prefix] = config
 		logrus.Infof("Serving channels from %v with subkey %q at /%s", sources, subkey, prefix)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,12 +10,17 @@ import (
 
 	"github.com/google/go-github/v67/github"
 	"github.com/rancher/channelserver/pkg/model"
+	"github.com/rancher/channelserver/pkg/wait"
 	"github.com/sirupsen/logrus"
 )
+
+type Wait wait.Wait // retained in this package for backwards compatibility
 
 type Config struct {
 	sync.Mutex
 	refreshMu sync.Mutex
+
+	Valid bool
 
 	subKey               string
 	channelServerVersion string
@@ -31,25 +36,8 @@ type Config struct {
 	appDefaultsConfig *model.AppDefaultsConfig
 }
 
-type Wait interface {
-	Wait(ctx context.Context) bool
-}
-
 type Source interface {
 	URL() string
-}
-
-type DurationWait struct {
-	Duration time.Duration
-}
-
-func (d *DurationWait) Wait(ctx context.Context) bool {
-	select {
-	case <-ctx.Done():
-		return false
-	case <-time.After(d.Duration):
-		return true
-	}
 }
 
 type StringSource string
@@ -58,7 +46,7 @@ func (s StringSource) URL() string {
 	return string(s)
 }
 
-func NewConfig(ctx context.Context, subKey string, wait Wait, channelServerVersion string, appName string, ghToken string, urls []Source) *Config {
+func NewConfig(ctx context.Context, subKey string, wait Wait, channelServerVersion string, appName string, ghToken string, urls []Source, fatal bool) *Config {
 	c := &Config{
 		subKey:               subKey,
 		channelServerVersion: channelServerVersion,
@@ -73,18 +61,26 @@ func NewConfig(ctx context.Context, subKey string, wait Wait, channelServerVersi
 
 	logrus.Infof("Loading configuration from %v", urls)
 	if err := c.LoadConfig(ctx); err != nil {
-		logrus.Fatalf("Failed to load initial config for %s: %v", subKey, err)
+		logrus.Fatalf("Failed to load initial config for subkey %q: %v", subKey, err)
 	}
 
-	logrus.Infof("Loaded initial configuration for %s", subKey)
+	logrus.Infof("Loaded initial configuration for subkey %q", subKey)
+	c.Valid = true
 
 	if wait != nil {
 		go func() {
 			for wait.Wait(ctx) {
+				start := time.Now()
 				if err := c.LoadConfig(ctx); err != nil {
-					logrus.Errorf("Failed to reload configuration for %s: %v", subKey, err)
+					if fatal {
+						logrus.Fatalf("Failed to reload configuration for subkey %q: %v", subKey, err)
+					} else {
+						logrus.Errorf("Failed to reload configuration for subkey %q: %v", subKey, err)
+					}
+					c.Valid = false
 				} else {
-					logrus.Infof("Reloaded configuration for %s", subKey)
+					logrus.Infof("Reloaded configuration for subkey %q in %s", subKey, time.Since(start))
+					c.Valid = true
 				}
 			}
 		}()
@@ -154,7 +150,7 @@ func (c *Config) ghClient(config *model.ChannelsConfig) (*github.Client, error) 
 	}
 
 	if c.gh == nil || c.url != config.GitHub.APIURL {
-		client := github.NewClient(nil)
+		client := github.NewClient(httpClient)
 		if c.ghToken != "" {
 			client = client.WithAuthToken(c.ghToken)
 		}

--- a/pkg/config/get.go
+++ b/pkg/config/get.go
@@ -12,14 +12,24 @@ import (
 	"github.com/google/go-github/v67/github"
 	"github.com/rancher/channelserver/pkg/model"
 	"github.com/rancher/wrangler/v3/pkg/data/convert"
+	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
 )
 
 var (
+	pageSize   = 100
 	httpClient = &http.Client{
-		Timeout: time.Second * 5,
+		Timeout:   time.Second * 5,
+		Transport: &loggingTransport{},
 	}
 )
+
+type loggingTransport struct{}
+
+func (l *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	logrus.Debugf("Making request: %s %s", req.Method, req.URL)
+	return http.DefaultTransport.RoundTrip(req)
+}
 
 func getURLs(ctx context.Context, urls ...Source) ([]byte, int, error) {
 	var (
@@ -136,7 +146,7 @@ func GetReleasesConfig(content []byte, channelServerVersion, subKey string) (*mo
 
 func GetGHReleases(ctx context.Context, client *github.Client, owner, repo string) ([]string, error) {
 	var (
-		opt         = &github.ListOptions{}
+		opt         = &github.ListOptions{PerPage: pageSize}
 		allReleases []string
 	)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -44,8 +44,10 @@ func ListenAndServe(ctx context.Context, address string, configs map[string]*con
 
 func NewHandler(configs map[string]*config.Config) http.Handler {
 	var apiserver *server.Server
+	var liveconfig *config.Config
 	router := http.NewServeMux()
 	for prefix, config := range configs {
+		liveconfig = config
 		apiserver = server.DefaultAPIServer()
 		apiserver.Schemas.MustImportAndCustomize(model.Channel{}, func(schema *types.APISchema) {
 			schema.Store = channel.New(config)
@@ -68,6 +70,17 @@ func NewHandler(configs map[string]*config.Config) http.Handler {
 	if apiserver != nil {
 		router.Handle("/{$}", setPathValues(apiserver, "apiRoot", ""))
 		router.Handle("/{name}", setPathValues(apiserver, "apiRoot", ""))
+	}
+	if liveconfig != nil {
+		router.Handle("/livez", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if liveconfig.Valid {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("configuration is valid\r\n"))
+			} else {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("configuration is stale\r\n"))
+			}
+		}))
 	}
 	return router
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/url"
 	"os"
@@ -18,18 +19,27 @@ import (
 )
 
 func ListenAndServe(ctx context.Context, address string, configs map[string]*config.Config) error {
-	h := NewHandler(configs)
+	next := LoggingHandler(os.Stdout, NewHandler(configs))
+	server := http.Server{
+		Addr: address,
+		Handler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			user := req.Header.Get("X-SUC-Cluster-ID")
+			if user != "" && req.URL != nil {
+				req.URL.User = url.User(user)
+			}
+			next.ServeHTTP(rw, req)
+		}),
+	}
 
-	next := LoggingHandler(os.Stdout, h)
-	handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		user := req.Header.Get("X-SUC-Cluster-ID")
-		if user != "" && req.URL != nil {
-			req.URL.User = url.User(user)
-		}
-		next.ServeHTTP(rw, req)
-	})
+	go func() {
+		<-ctx.Done()
+		server.Shutdown(context.Background())
+	}()
 
-	return http.ListenAndServe(address, handler)
+	if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
 }
 
 func NewHandler(configs map[string]*config.Config) http.Handler {

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -1,0 +1,62 @@
+package wait
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	"github.com/sirupsen/logrus"
+)
+
+type Wait interface {
+	Wait(ctx context.Context) bool
+}
+
+type schedule struct {
+	cron *cron.Cron
+	tick chan struct{}
+}
+
+func (s *schedule) Wait(ctx context.Context) bool {
+	s.cron.Start()
+	select {
+	case <-ctx.Done():
+		s.cron.Stop()
+		return false
+	case <-s.tick:
+		return true
+	}
+}
+
+func NewSchedule(expression string) (Wait, error) {
+	ticker := make(chan struct{})
+	logger := cron.VerbosePrintfLogger(logrus.StandardLogger().WithField("name", "refresh-schedule-cron"))
+	job := cron.SkipIfStillRunning(logger)(cron.FuncJob(func() { ticker <- struct{}{} }))
+	c := cron.New(cron.WithLogger(logger))
+	if _, err := c.AddJob(expression, job); err != nil {
+		return nil, fmt.Errorf("failed to parse cron expression %q: %w", expression, err)
+	}
+	return &schedule{cron: c, tick: ticker}, nil
+}
+
+type interval struct {
+	interval time.Duration
+}
+
+func (i *interval) Wait(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(i.interval):
+		return true
+	}
+}
+
+func NewInterval(duration string) (Wait, error) {
+	intval, err := time.ParseDuration(duration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse duration %q: %w", duration, err)
+	}
+	return &interval{interval: intval}, nil
+}


### PR DESCRIPTION
#### Description
* Add support for scheduling config reload via cron expression instead of at fixed intervals after startup
* Add /livez handler, returns error if most recent config reload has failed
* Add option to exit with fatal error if config reload fails, instead of continuing to serve stale config
* Add debug flag; prints config reload HTTP requests at debug level

#### Linked Issues
* https://github.com/rancher/channelserver/issues/37
* https://github.com/k3s-io/k3s/issues/14282