### PR TITLE
Optionally support creating Scarf events based on channelserver polls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,10 @@ toolchain go1.26.3
 replace k8s.io/client-go => k8s.io/client-go v0.36.0
 
 require (
+	github.com/axiomhq/hyperloglog v0.2.6
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/google/go-github/v67 v67.0.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/apiserver v0.9.5
 	github.com/rancher/wrangler/v3 v3.7.0
@@ -23,12 +25,14 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
+	github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kamstrup/intmap v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/axiomhq/hyperloglog v0.2.6 h1:sRhvvF3RIXWQgAXaTphLp4yJiX4S0IN3MWTaAgZoRJw=
+github.com/axiomhq/hyperloglog v0.2.6/go.mod h1:YjX/dQqCR/7QYX0g8mu8UZAjpIenz1FKM71UEsjFoTo=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
@@ -13,6 +15,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33 h1:ucRHb6/lvW/+mTEIGbvhcYU3S8+uSNkuMjx/qZFfhtM=
+github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -31,8 +35,12 @@ github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kamstrup/intmap v0.5.2 h1:qnwBm1mh4XAnW9W9Ue9tZtTff8pS6+s6iKF6JRIV2Dk=
+github.com/kamstrup/intmap v0.5.2/go.mod h1:gWUVWHKzWj8xpJVFf5GC0O26bWmv3GqdnIX/LMT6Aq4=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/main.go
+++ b/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rancher/channelserver/pkg/config"
+	"github.com/rancher/channelserver/pkg/scarf"
 	"github.com/rancher/channelserver/pkg/server"
 	"github.com/rancher/channelserver/pkg/wait"
 	"github.com/rancher/wrangler/v3/pkg/signals"
@@ -29,6 +31,8 @@ var (
 	SubKeys              cli.StringSlice
 	PathPrefix           cli.StringSlice
 	ScarfEndpoint        string
+	ScarfRateLimitWindow time.Duration
+	ScarfRateLimitSize   int
 )
 
 func main() {
@@ -106,6 +110,20 @@ func main() {
 			EnvVars:     []string{"SCARF_ENDPOINT"},
 			Destination: &ScarfEndpoint,
 		},
+		&cli.DurationFlag{
+			Name:        "scarf-rate-limit-window",
+			Usage:       "per-cluster Scarf event rate-limit window (e.g. 24h); 0 disables",
+			EnvVars:     []string{"SCARF_RATE_LIMIT_WINDOW"},
+			Value:       24 * time.Hour,
+			Destination: &ScarfRateLimitWindow,
+		},
+		&cli.IntFlag{
+			Name:        "scarf-rate-limit-size",
+			Usage:       "max distinct cluster IDs tracked for rate limiting",
+			EnvVars:     []string{"SCARF_RATE_LIMIT_SIZE"},
+			Value:       scarf.DefaultCacheSize,
+			Destination: &ScarfRateLimitSize,
+		},
 	}
 	app.Action = run
 
@@ -150,5 +168,10 @@ func run(c *cli.Context) error {
 		configs[prefix] = config
 		logrus.Infof("Serving channels from %v with subkey %q at /%s", sources, subkey, prefix)
 	}
-	return server.ListenAndServe(ctx, ListenAddress, configs, ScarfEndpoint)
+
+	if ScarfRateLimitWindow < 0 {
+		return errors.Errorf("scarf-rate-limit-window must be >= 0, got %v", ScarfRateLimitWindow)
+	}
+	svc := scarf.New(ctx, ScarfEndpoint, ScarfRateLimitWindow, ScarfRateLimitSize)
+	return server.ListenAndServe(ctx, ListenAddress, configs, svc)
 }

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ var (
 	URLs                 cli.StringSlice
 	SubKeys              cli.StringSlice
 	PathPrefix           cli.StringSlice
+	ScarfEndpoint        string
 )
 
 func main() {
@@ -99,6 +100,12 @@ func main() {
 			EnvVars:     []string{"DEBUG"},
 			Destination: &Debug,
 		},
+		&cli.StringFlag{
+			Name:        "scarf-endpoint",
+			Usage:       "Scarf gateway endpoint template with a {channel} placeholder; empty disables reporting",
+			EnvVars:     []string{"SCARF_ENDPOINT"},
+			Destination: &ScarfEndpoint,
+		},
 	}
 	app.Action = run
 
@@ -143,5 +150,5 @@ func run(c *cli.Context) error {
 		configs[prefix] = config
 		logrus.Infof("Serving channels from %v with subkey %q at /%s", sources, subkey, prefix)
 	}
-	return server.ListenAndServe(ctx, ListenAddress, configs)
+	return server.ListenAndServe(ctx, ListenAddress, configs, ScarfEndpoint)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -236,14 +236,16 @@ func (c *Config) AppDefaultsConfig() *model.AppDefaultsConfig {
 	return c.appDefaultsConfig
 }
 
-func (c *Config) Redirect(id string) (string, error) {
+// Redirect resolves a channel id to its redirect URL and resolved version;
+// both empty when the channel is unknown or has no latest version.
+func (c *Config) Redirect(id string) (string, string, error) {
 	for _, channel := range c.channelsConfig.Channels {
 		if channel.Name == id && channel.Latest != "" {
 			return c.redirect.ResolveReference(&url.URL{
 				Path: channel.Latest,
-			}).String(), nil
+			}).String(), channel.Latest, nil
 		}
 	}
 
-	return "", nil
+	return "", "", nil
 }

--- a/pkg/scarf/limiter.go
+++ b/pkg/scarf/limiter.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/axiomhq/hyperloglog"
-	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"github.com/sirupsen/logrus"
 )
 
@@ -20,7 +20,7 @@ const (
 type limiter struct {
 	mu       sync.Mutex
 	window   time.Duration
-	cache    *lru.Cache[string, time.Time]
+	cache    *simplelru.LRU[string, time.Time]
 	capacity int
 	day      *hyperloglog.Sketch
 	total    *hyperloglog.Sketch
@@ -47,7 +47,7 @@ func newLimiter(window time.Duration, size int) *limiter {
 			size = DefaultCacheSize
 		}
 		l.capacity = size
-		cache, err := lru.NewWithEvict(size, func(_ string, _ time.Time) {
+		cache, err := simplelru.NewLRU(size, func(_ string, _ time.Time) {
 			l.evictions.Add(1)
 		})
 		if err != nil {
@@ -72,7 +72,8 @@ func (l *limiter) allow(key string) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	l.rolloverLocked()
+	now := l.now()
+	l.rolloverLocked(now)
 	kb := []byte(key)
 	l.day.Insert(kb)
 	l.total.Insert(kb)
@@ -82,7 +83,6 @@ func (l *limiter) allow(key string) bool {
 		return true
 	}
 
-	now := l.now()
 	if last, ok := l.cache.Get(key); ok && now.Sub(last) < l.window {
 		l.suppressed.Add(1)
 		return false
@@ -93,8 +93,8 @@ func (l *limiter) allow(key string) bool {
 	return true
 }
 
-func (l *limiter) rolloverLocked() {
-	k := dayKey(l.now())
+func (l *limiter) rolloverLocked(now time.Time) {
+	k := dayKey(now)
 	if k == l.dayKey {
 		return
 	}
@@ -105,7 +105,7 @@ func (l *limiter) rolloverLocked() {
 
 func (l *limiter) report() {
 	l.mu.Lock()
-	l.rolloverLocked()
+	l.rolloverLocked(l.now())
 	distinctDay := l.day.Estimate()
 	distinctTotal := l.total.Estimate()
 	cacheEntries := 0
@@ -126,8 +126,8 @@ func (l *limiter) report() {
 	}).Info("scarf rate-limit stats")
 }
 
-func (l *limiter) reportLoop(ctx context.Context, interval time.Duration) {
-	ticker := time.NewTicker(interval)
+func (l *limiter) reportLoop(ctx context.Context) {
+	ticker := time.NewTicker(reportInterval)
 	defer ticker.Stop()
 	for {
 		select {

--- a/pkg/scarf/limiter.go
+++ b/pkg/scarf/limiter.go
@@ -1,0 +1,140 @@
+package scarf
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/axiomhq/hyperloglog"
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// DefaultCacheSize is the default max number of distinct cluster IDs tracked.
+	DefaultCacheSize = 550000
+	reportInterval   = time.Hour
+)
+
+type limiter struct {
+	mu       sync.Mutex
+	window   time.Duration
+	cache    *lru.Cache[string, time.Time]
+	capacity int
+	day      *hyperloglog.Sketch
+	total    *hyperloglog.Sketch
+	dayKey   int
+	now      func() time.Time
+
+	sent       atomic.Uint64
+	suppressed atomic.Uint64
+	anonSent   atomic.Uint64
+	evictions  atomic.Uint64
+}
+
+func newLimiter(window time.Duration, size int) *limiter {
+	l := &limiter{
+		window: window,
+		day:    hyperloglog.New14(),
+		total:  hyperloglog.New14(),
+		now:    time.Now,
+	}
+	l.dayKey = dayKey(l.now())
+
+	if window > 0 {
+		if size <= 0 {
+			size = DefaultCacheSize
+		}
+		l.capacity = size
+		cache, err := lru.NewWithEvict(size, func(_ string, _ time.Time) {
+			l.evictions.Add(1)
+		})
+		if err != nil {
+			logrus.Errorf("failed to create rate-limit cache: %v", err)
+		} else {
+			l.cache = cache
+		}
+	}
+	return l
+}
+
+func dayKey(t time.Time) int {
+	return t.Year()*1000 + t.YearDay()
+}
+
+func (l *limiter) allow(key string) bool {
+	if key == "" {
+		l.anonSent.Add(1)
+		return true
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.rolloverLocked()
+	kb := []byte(key)
+	l.day.Insert(kb)
+	l.total.Insert(kb)
+
+	if l.window <= 0 || l.cache == nil {
+		l.sent.Add(1)
+		return true
+	}
+
+	now := l.now()
+	if last, ok := l.cache.Get(key); ok && now.Sub(last) < l.window {
+		l.suppressed.Add(1)
+		return false
+	}
+
+	l.cache.Add(key, now)
+	l.sent.Add(1)
+	return true
+}
+
+func (l *limiter) rolloverLocked() {
+	k := dayKey(l.now())
+	if k == l.dayKey {
+		return
+	}
+	logrus.WithField("distinct_day", l.day.Estimate()).Info("scarf daily rollover")
+	l.day = hyperloglog.New14()
+	l.dayKey = k
+}
+
+func (l *limiter) report() {
+	l.mu.Lock()
+	l.rolloverLocked()
+	distinctDay := l.day.Estimate()
+	distinctTotal := l.total.Estimate()
+	cacheEntries := 0
+	if l.cache != nil {
+		cacheEntries = l.cache.Len()
+	}
+	l.mu.Unlock()
+
+	logrus.WithFields(logrus.Fields{
+		"distinct_day":   distinctDay,
+		"distinct_total": distinctTotal,
+		"cache_entries":  cacheEntries,
+		"cache_cap":      l.capacity,
+		"evictions":      l.evictions.Load(),
+		"sent":           l.sent.Load(),
+		"suppressed":     l.suppressed.Load(),
+		"anon_sent":      l.anonSent.Load(),
+	}).Info("scarf rate-limit stats")
+}
+
+func (l *limiter) reportLoop(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			l.report()
+		}
+	}
+}

--- a/pkg/scarf/limiter_test.go
+++ b/pkg/scarf/limiter_test.go
@@ -1,0 +1,162 @@
+package scarf
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_UnitLimiterRateLimit(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	l := newLimiter(time.Hour, 1000)
+	l.now = func() time.Time { return now }
+
+	if !l.allow("c1") {
+		t.Error("first allow(c1) should be true")
+	}
+	if l.allow("c1") {
+		t.Error("immediate second allow(c1) should be false (rate-limited)")
+	}
+
+	now = now.Add(2 * time.Hour)
+	if !l.allow("c1") {
+		t.Error("allow(c1) after window should be true")
+	}
+}
+
+func Test_UnitLimiterNoWindow(t *testing.T) {
+	l := newLimiter(0, 0)
+
+	if !l.allow("c1") {
+		t.Error("allow(c1) with window=0 should be true")
+	}
+	if !l.allow("c1") {
+		t.Error("second allow(c1) with window=0 should be true")
+	}
+
+	if l.sent.Load() != 2 {
+		t.Errorf("sent counter = %d, want 2", l.sent.Load())
+	}
+	if l.day.Estimate() == 0 {
+		t.Error("day.Estimate() should be > 0 (cardinality tracked even with window=0)")
+	}
+}
+
+func Test_UnitLimiterEmptyKey(t *testing.T) {
+	l := newLimiter(time.Hour, 1000)
+
+	if !l.allow("") {
+		t.Error("allow(\"\") should be true")
+	}
+	if !l.allow("") {
+		t.Error("second allow(\"\") should be true (not rate-limited)")
+	}
+
+	if l.anonSent.Load() != 2 {
+		t.Errorf("anonSent = %d, want 2", l.anonSent.Load())
+	}
+	if l.day.Estimate() != 0 {
+		t.Errorf("day.Estimate() = %d, want 0 (empty keys not counted)", l.day.Estimate())
+	}
+}
+
+func Test_UnitLimiterIndependentKeys(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	l := newLimiter(time.Hour, 1000)
+	l.now = func() time.Time { return now }
+
+	if !l.allow("c1") {
+		t.Error("first allow(c1) should be true")
+	}
+	if l.allow("c1") {
+		t.Error("second allow(c1) should be false")
+	}
+	if !l.allow("c2") {
+		t.Error("allow(c2) should be true (independent from c1)")
+	}
+}
+
+func Test_UnitLimiterEviction(t *testing.T) {
+	l := newLimiter(time.Hour, 1)
+
+	if !l.allow("a") {
+		t.Error("allow(a) should be true")
+	}
+	if !l.allow("b") {
+		t.Error("allow(b) should be true (evicts a)")
+	}
+
+	if l.evictions.Load() != 1 {
+		t.Errorf("evictions = %d, want 1", l.evictions.Load())
+	}
+
+	if !l.allow("a") {
+		t.Error("allow(a) should be true again (was evicted)")
+	}
+}
+
+func Test_UnitLimiterHLLAccuracy(t *testing.T) {
+	l := newLimiter(0, 0)
+
+	const count = 1000
+	for i := 0; i < count; i++ {
+		l.allow(string(rune('a'+i%26)) + string(rune('0'+i/26)))
+	}
+
+	estimate := l.day.Estimate()
+	lower := uint64(float64(count) * 0.95)
+	upper := uint64(float64(count) * 1.05)
+	if estimate < lower || estimate > upper {
+		t.Errorf("day.Estimate() = %d, want within [%d, %d] (±5%% of %d)", estimate, lower, upper, count)
+	}
+
+	totalEstimate := l.total.Estimate()
+	if totalEstimate < lower || totalEstimate > upper {
+		t.Errorf("total.Estimate() = %d, want within [%d, %d] (±5%% of %d)", totalEstimate, lower, upper, count)
+	}
+}
+
+func Test_UnitLimiterRollover(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	l := newLimiter(0, 0)
+	l.now = func() time.Time { return now }
+
+	l.allow("c1")
+	l.allow("c2")
+
+	totalBefore := l.total.Estimate()
+
+	now = now.Add(24 * time.Hour)
+	l.report()
+
+	dayAfter := l.day.Estimate()
+	totalAfter := l.total.Estimate()
+
+	if dayAfter != 0 {
+		t.Errorf("day.Estimate() after rollover = %d, want 0", dayAfter)
+	}
+	if totalAfter < totalBefore {
+		t.Errorf("total.Estimate() after rollover = %d, should be >= %d (total persists)", totalAfter, totalBefore)
+	}
+}
+
+func Test_UnitLimiterCounters(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	l := newLimiter(time.Hour, 1000)
+	l.now = func() time.Time { return now }
+
+	l.allow("c1")
+	l.allow("c1")
+	l.allow("c2")
+	l.allow("")
+	l.allow("")
+
+	if got := l.sent.Load(); got != 2 {
+		t.Errorf("sent = %d, want 2 (c1 first time, c2 first time)", got)
+	}
+	if got := l.suppressed.Load(); got != 1 {
+		t.Errorf("suppressed = %d, want 1 (c1 second time)", got)
+	}
+	if got := l.anonSent.Load(); got != 2 {
+		t.Errorf("anonSent = %d, want 2 (empty keys)", got)
+	}
+}

--- a/pkg/scarf/scarf.go
+++ b/pkg/scarf/scarf.go
@@ -40,10 +40,10 @@ func New(ctx context.Context, endpoint string, window time.Duration, size int) *
 	s := &Service{
 		client:   &http.Client{Timeout: requestTimeout},
 		endpoint: endpoint,
-		limiter:  newLimiter(window, size),
 	}
 	if endpoint != "" {
-		go s.limiter.reportLoop(ctx, reportInterval)
+		s.limiter = newLimiter(window, size)
+		go s.limiter.reportLoop(ctx)
 	}
 	return s
 }

--- a/pkg/scarf/scarf.go
+++ b/pkg/scarf/scarf.go
@@ -4,6 +4,7 @@ package scarf
 import (
 	"context"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -48,21 +49,29 @@ func New(ctx context.Context, endpoint string, window time.Duration, size int) *
 	return s
 }
 
-// Send fires the event in the background; no-op when endpoint is empty.
-// Failures are logged, never returned or blocking.
-func (s *Service) Send(event Event) {
+// Send reports a resolved channel in a background goroutine; no-op when
+// disabled. Reads headers/IP only past the rate-limit gate; never blocks.
+func (s *Service) Send(channel, resolvedVersion string, req *http.Request) {
 	if s.endpoint == "" {
 		return
 	}
-	if !s.limiter.allow(event.ClusterID) {
-		logrus.Debugf("rate-limited Scarf event for cluster %q channel %q", event.ClusterID, event.Channel)
+	clusterID := req.Header.Get("X-SUC-Cluster-ID")
+	if !s.limiter.allow(clusterID) {
+		logrus.Debugf("rate-limited Scarf event for cluster %q channel %q", clusterID, channel)
 		return
+	}
+	event := Event{
+		Channel:         channel,
+		ResolvedVersion: resolvedVersion,
+		LatestVersion:   req.Header.Get("X-SUC-Latest-Version"),
+		ClusterID:       clusterID,
+		ClientIP:        clientIP(req),
 	}
 	go func() {
 		if err := s.send(event); err != nil {
-			logrus.Errorf("failed to send Scarf event for channel %q: %v", event.Channel, err)
+			logrus.Errorf("failed to send Scarf event for channel %q: %v", channel, err)
 		} else {
-			logrus.Debugf("sent Scarf event for channel %q", event.Channel)
+			logrus.Debugf("sent Scarf event for channel %q", channel)
 		}
 	}()
 }
@@ -75,14 +84,14 @@ func (s *Service) send(event Event) error {
 	}
 
 	q := u.Query()
-	for key, value := range map[string]string{
-		"version_resolved": event.ResolvedVersion,
-		"version_latest":   event.LatestVersion,
-		"cluster_id":       event.ClusterID,
-	} {
-		if value != "" {
-			q.Set(key, value)
-		}
+	if event.ResolvedVersion != "" {
+		q.Set("version_resolved", event.ResolvedVersion)
+	}
+	if event.LatestVersion != "" {
+		q.Set("version_latest", event.LatestVersion)
+	}
+	if event.ClusterID != "" {
+		q.Set("cluster_id", event.ClusterID)
 	}
 	u.RawQuery = q.Encode()
 
@@ -102,4 +111,19 @@ func (s *Service) send(event Event) error {
 	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
+}
+
+// clientIP returns the real client for the X-Scarf-IP header: first
+// X-Forwarded-For hop (we run behind a load balancer), else RemoteAddr host.
+func clientIP(req *http.Request) string {
+	if xff := req.Header.Get("X-Forwarded-For"); xff != "" {
+		if first := strings.TrimSpace(strings.Split(xff, ",")[0]); first != "" {
+			return first
+		}
+	}
+	host, _, err := net.SplitHostPort(req.RemoteAddr)
+	if err != nil {
+		return req.RemoteAddr
+	}
+	return host
 }

--- a/pkg/scarf/scarf.go
+++ b/pkg/scarf/scarf.go
@@ -2,6 +2,7 @@
 package scarf
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -28,22 +29,37 @@ type Event struct {
 
 // Service sends events to a Scarf gateway endpoint.
 type Service struct {
-	client *http.Client
+	client   *http.Client
+	endpoint string
+	limiter  *limiter
 }
 
-// New returns a Service with a bounded HTTP client.
-func New() *Service {
-	return &Service{client: &http.Client{Timeout: requestTimeout}}
+// New returns a Service reporting to endpoint, rate-limiting per cluster
+// within window (0 disables), tracking up to size distinct clusters.
+func New(ctx context.Context, endpoint string, window time.Duration, size int) *Service {
+	s := &Service{
+		client:   &http.Client{Timeout: requestTimeout},
+		endpoint: endpoint,
+		limiter:  newLimiter(window, size),
+	}
+	if endpoint != "" {
+		go s.limiter.reportLoop(ctx, reportInterval)
+	}
+	return s
 }
 
-// Send fires the event to endpointTemplate in the background; no-op when
-// empty. Failures are logged, never returned or blocking.
-func (s *Service) Send(endpointTemplate string, event Event) {
-	if endpointTemplate == "" {
+// Send fires the event in the background; no-op when endpoint is empty.
+// Failures are logged, never returned or blocking.
+func (s *Service) Send(event Event) {
+	if s.endpoint == "" {
+		return
+	}
+	if !s.limiter.allow(event.ClusterID) {
+		logrus.Debugf("rate-limited Scarf event for cluster %q channel %q", event.ClusterID, event.Channel)
 		return
 	}
 	go func() {
-		if err := s.send(endpointTemplate, event); err != nil {
+		if err := s.send(event); err != nil {
 			logrus.Errorf("failed to send Scarf event for channel %q: %v", event.Channel, err)
 		} else {
 			logrus.Debugf("sent Scarf event for channel %q", event.Channel)
@@ -51,8 +67,8 @@ func (s *Service) Send(endpointTemplate string, event Event) {
 	}()
 }
 
-func (s *Service) send(endpointTemplate string, event Event) error {
-	endpoint := strings.ReplaceAll(endpointTemplate, channelPlaceholder, url.PathEscape(event.Channel))
+func (s *Service) send(event Event) error {
+	endpoint := strings.ReplaceAll(s.endpoint, channelPlaceholder, url.PathEscape(event.Channel))
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return err

--- a/pkg/scarf/scarf.go
+++ b/pkg/scarf/scarf.go
@@ -1,0 +1,89 @@
+// Package scarf reports channel-resolution events to a Scarf gateway.
+package scarf
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	channelPlaceholder = "{channel}"
+	requestTimeout     = 5 * time.Second
+	userAgent          = "channelserver"
+)
+
+// Event holds the data reported for a single channel resolution.
+type Event struct {
+	Channel         string
+	ResolvedVersion string
+	LatestVersion   string // X-SUC-Latest-Version, set only by system-upgrade-controller
+	ClusterID       string // X-SUC-Cluster-ID, set only by system-upgrade-controller
+	ClientIP        string
+}
+
+// Service sends events to a Scarf gateway endpoint.
+type Service struct {
+	client *http.Client
+}
+
+// New returns a Service with a bounded HTTP client.
+func New() *Service {
+	return &Service{client: &http.Client{Timeout: requestTimeout}}
+}
+
+// Send fires the event to endpointTemplate in the background; no-op when
+// empty. Failures are logged, never returned or blocking.
+func (s *Service) Send(endpointTemplate string, event Event) {
+	if endpointTemplate == "" {
+		return
+	}
+	go func() {
+		if err := s.send(endpointTemplate, event); err != nil {
+			logrus.Errorf("failed to send Scarf event for channel %q: %v", event.Channel, err)
+		} else {
+			logrus.Debugf("sent Scarf event for channel %q", event.Channel)
+		}
+	}()
+}
+
+func (s *Service) send(endpointTemplate string, event Event) error {
+	endpoint := strings.ReplaceAll(endpointTemplate, channelPlaceholder, url.PathEscape(event.Channel))
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return err
+	}
+
+	q := u.Query()
+	for key, value := range map[string]string{
+		"version_resolved": event.ResolvedVersion,
+		"version_latest":   event.LatestVersion,
+		"cluster_id":       event.ClusterID,
+	} {
+		if value != "" {
+			q.Set(key, value)
+		}
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	if event.ClientIP != "" {
+		req.Header.Set("X-Scarf-IP", event.ClientIP)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}

--- a/pkg/scarf/scarf_test.go
+++ b/pkg/scarf/scarf_test.go
@@ -1,0 +1,70 @@
+package scarf
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func Test_UnitSendSUC(t *testing.T) {
+	got := make(chan *http.Request, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got <- r
+	}))
+	defer srv.Close()
+
+	err := New().send(srv.URL+"/rke2-channelserver/{channel}", Event{
+		Channel:         "stable",
+		ResolvedVersion: "v1.31.5+rke2r1",
+		LatestVersion:   "v1.31.4+rke2r1",
+		ClusterID:       "abc-123",
+		ClientIP:        "203.0.113.7",
+	})
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	req := <-got
+	if req.URL.Path != "/rke2-channelserver/stable" {
+		t.Errorf("path = %q, want /rke2-channelserver/stable", req.URL.Path)
+	}
+	q := req.URL.Query()
+	for key, want := range map[string]string{
+		"version_resolved": "v1.31.5+rke2r1",
+		"version_latest":   "v1.31.4+rke2r1",
+		"cluster_id":       "abc-123",
+	} {
+		if got := q.Get(key); got != want {
+			t.Errorf("query %s = %q, want %q", key, got, want)
+		}
+	}
+	if got := req.Header.Get("X-Scarf-IP"); got != "203.0.113.7" {
+		t.Errorf("X-Scarf-IP = %q, want 203.0.113.7", got)
+	}
+}
+
+func Test_UnitSendInstall(t *testing.T) {
+	got := make(chan *http.Request, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got <- r
+	}))
+	defer srv.Close()
+
+	err := New().send(srv.URL+"/rke2-channelserver/{channel}", Event{
+		Channel:         "stable",
+		ResolvedVersion: "v1.31.5+rke2r1",
+		ClientIP:        "203.0.113.7",
+	})
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	req := <-got
+	q := req.URL.Query()
+	if q.Has("version_latest") {
+		t.Errorf("version_latest should be absent for install.sh requests")
+	}
+	if q.Has("cluster_id") {
+		t.Errorf("cluster_id should be absent for install.sh requests")
+	}
+}

--- a/pkg/scarf/scarf_test.go
+++ b/pkg/scarf/scarf_test.go
@@ -1,6 +1,7 @@
 package scarf
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,7 +14,9 @@ func Test_UnitSendSUC(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	err := New().send(srv.URL+"/rke2-channelserver/{channel}", Event{
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	err := New(ctx, srv.URL+"/rke2-channelserver/{channel}", 0, 0).send(Event{
 		Channel:         "stable",
 		ResolvedVersion: "v1.31.5+rke2r1",
 		LatestVersion:   "v1.31.4+rke2r1",
@@ -50,7 +53,9 @@ func Test_UnitSendInstall(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	err := New().send(srv.URL+"/rke2-channelserver/{channel}", Event{
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	err := New(ctx, srv.URL+"/rke2-channelserver/{channel}", 0, 0).send(Event{
 		Channel:         "stable",
 		ResolvedVersion: "v1.31.5+rke2r1",
 		ClientIP:        "203.0.113.7",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,8 +18,8 @@ import (
 	"github.com/rancher/channelserver/pkg/server/store/release"
 )
 
-func ListenAndServe(ctx context.Context, address string, configs map[string]*config.Config) error {
-	next := LoggingHandler(os.Stdout, NewHandler(configs))
+func ListenAndServe(ctx context.Context, address string, configs map[string]*config.Config, scarfEndpoint string) error {
+	next := LoggingHandler(os.Stdout, NewHandler(configs, scarfEndpoint))
 	server := http.Server{
 		Addr: address,
 		Handler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -42,7 +42,7 @@ func ListenAndServe(ctx context.Context, address string, configs map[string]*con
 	return nil
 }
 
-func NewHandler(configs map[string]*config.Config) http.Handler {
+func NewHandler(configs map[string]*config.Config, scarfEndpoint string) http.Handler {
 	var apiserver *server.Server
 	var liveconfig *config.Config
 	router := http.NewServeMux()
@@ -50,7 +50,7 @@ func NewHandler(configs map[string]*config.Config) http.Handler {
 		liveconfig = config
 		apiserver = server.DefaultAPIServer()
 		apiserver.Schemas.MustImportAndCustomize(model.Channel{}, func(schema *types.APISchema) {
-			schema.Store = channel.New(config)
+			schema.Store = channel.New(config, scarfEndpoint)
 			schema.CollectionMethods = []string{http.MethodGet}
 			schema.ResourceMethods = []string{http.MethodGet}
 		})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -13,13 +13,14 @@ import (
 	"github.com/rancher/apiserver/pkg/types"
 	"github.com/rancher/channelserver/pkg/config"
 	"github.com/rancher/channelserver/pkg/model"
+	"github.com/rancher/channelserver/pkg/scarf"
 	"github.com/rancher/channelserver/pkg/server/store/appdefault"
 	"github.com/rancher/channelserver/pkg/server/store/channel"
 	"github.com/rancher/channelserver/pkg/server/store/release"
 )
 
-func ListenAndServe(ctx context.Context, address string, configs map[string]*config.Config, scarfEndpoint string) error {
-	next := LoggingHandler(os.Stdout, NewHandler(configs, scarfEndpoint))
+func ListenAndServe(ctx context.Context, address string, configs map[string]*config.Config, svc *scarf.Service) error {
+	next := LoggingHandler(os.Stdout, NewHandler(configs, svc))
 	server := http.Server{
 		Addr: address,
 		Handler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -42,7 +43,7 @@ func ListenAndServe(ctx context.Context, address string, configs map[string]*con
 	return nil
 }
 
-func NewHandler(configs map[string]*config.Config, scarfEndpoint string) http.Handler {
+func NewHandler(configs map[string]*config.Config, svc *scarf.Service) http.Handler {
 	var apiserver *server.Server
 	var liveconfig *config.Config
 	router := http.NewServeMux()
@@ -50,7 +51,7 @@ func NewHandler(configs map[string]*config.Config, scarfEndpoint string) http.Ha
 		liveconfig = config
 		apiserver = server.DefaultAPIServer()
 		apiserver.Schemas.MustImportAndCustomize(model.Channel{}, func(schema *types.APISchema) {
-			schema.Store = channel.New(config, scarfEndpoint)
+			schema.Store = channel.New(config, svc)
 			schema.CollectionMethods = []string{http.MethodGet}
 			schema.ResourceMethods = []string{http.MethodGet}
 		})

--- a/pkg/server/store/channel/store.go
+++ b/pkg/server/store/channel/store.go
@@ -14,16 +14,14 @@ import (
 
 type Channel struct {
 	empty.Store
-	config        *config.Config
-	scarf         *scarf.Service
-	scarfEndpoint string
+	config *config.Config
+	scarf  *scarf.Service
 }
 
-func New(config *config.Config, scarfEndpoint string) *Channel {
+func New(config *config.Config, svc *scarf.Service) *Channel {
 	return &Channel{
-		config:        config,
-		scarf:         scarf.New(),
-		scarfEndpoint: scarfEndpoint,
+		config: config,
+		scarf:  svc,
 	}
 }
 
@@ -46,7 +44,7 @@ func (c *Channel) ByID(apiOp *types.APIRequest, schema *types.APISchema, id stri
 		return types.APIObject{}, nil
 	}
 	if redirect != "" {
-		c.scarf.Send(c.scarfEndpoint, scarf.Event{
+		c.scarf.Send(scarf.Event{
 			Channel:         id,
 			ResolvedVersion: version,
 			LatestVersion:   apiOp.Request.Header.Get("X-SUC-Latest-Version"),

--- a/pkg/server/store/channel/store.go
+++ b/pkg/server/store/channel/store.go
@@ -1,22 +1,29 @@
 package channel
 
 import (
+	"net"
 	"net/http"
+	"strings"
 
 	"github.com/rancher/apiserver/pkg/store/empty"
 	"github.com/rancher/apiserver/pkg/types"
 	"github.com/rancher/channelserver/pkg/config"
+	"github.com/rancher/channelserver/pkg/scarf"
 	"github.com/rancher/wrangler/v3/pkg/schemas/validation"
 )
 
 type Channel struct {
 	empty.Store
-	config *config.Config
+	config        *config.Config
+	scarf         *scarf.Service
+	scarfEndpoint string
 }
 
-func New(config *config.Config) *Channel {
+func New(config *config.Config, scarfEndpoint string) *Channel {
 	return &Channel{
-		config: config,
+		config:        config,
+		scarf:         scarf.New(),
+		scarfEndpoint: scarfEndpoint,
 	}
 }
 
@@ -34,13 +41,35 @@ func (c *Channel) List(req *types.APIRequest, _ *types.APISchema) (types.APIObje
 }
 
 func (c *Channel) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
-	redirect, err := c.config.Redirect(id)
+	redirect, version, err := c.config.Redirect(id)
 	if err != nil {
 		return types.APIObject{}, nil
 	}
 	if redirect != "" {
+		c.scarf.Send(c.scarfEndpoint, scarf.Event{
+			Channel:         id,
+			ResolvedVersion: version,
+			LatestVersion:   apiOp.Request.Header.Get("X-SUC-Latest-Version"),
+			ClusterID:       apiOp.Request.Header.Get("X-SUC-Cluster-ID"),
+			ClientIP:        clientIP(apiOp.Request),
+		})
 		http.Redirect(apiOp.Response, apiOp.Request, redirect, http.StatusFound)
 		return types.APIObject{}, validation.ErrComplete
 	}
 	return c.Store.ByID(apiOp, schema, id)
+}
+
+// clientIP returns the client IP: first X-Forwarded-For hop (channelserver
+// runs behind a load balancer), else RemoteAddr.
+func clientIP(req *http.Request) string {
+	if xff := req.Header.Get("X-Forwarded-For"); xff != "" {
+		if first := strings.TrimSpace(strings.Split(xff, ",")[0]); first != "" {
+			return first
+		}
+	}
+	host, _, err := net.SplitHostPort(req.RemoteAddr)
+	if err != nil {
+		return req.RemoteAddr
+	}
+	return host
 }

--- a/pkg/server/store/channel/store.go
+++ b/pkg/server/store/channel/store.go
@@ -1,9 +1,7 @@
 package channel
 
 import (
-	"net"
 	"net/http"
-	"strings"
 
 	"github.com/rancher/apiserver/pkg/store/empty"
 	"github.com/rancher/apiserver/pkg/types"
@@ -44,30 +42,9 @@ func (c *Channel) ByID(apiOp *types.APIRequest, schema *types.APISchema, id stri
 		return types.APIObject{}, nil
 	}
 	if redirect != "" {
-		c.scarf.Send(scarf.Event{
-			Channel:         id,
-			ResolvedVersion: version,
-			LatestVersion:   apiOp.Request.Header.Get("X-SUC-Latest-Version"),
-			ClusterID:       apiOp.Request.Header.Get("X-SUC-Cluster-ID"),
-			ClientIP:        clientIP(apiOp.Request),
-		})
+		c.scarf.Send(id, version, apiOp.Request)
 		http.Redirect(apiOp.Response, apiOp.Request, redirect, http.StatusFound)
 		return types.APIObject{}, validation.ErrComplete
 	}
 	return c.Store.ByID(apiOp, schema, id)
-}
-
-// clientIP returns the client IP: first X-Forwarded-For hop (channelserver
-// runs behind a load balancer), else RemoteAddr.
-func clientIP(req *http.Request) string {
-	if xff := req.Header.Get("X-Forwarded-For"); xff != "" {
-		if first := strings.TrimSpace(strings.Split(xff, ",")[0]); first != "" {
-			return first
-		}
-	}
-	host, _, err := net.SplitHostPort(req.RemoteAddr)
-	if err != nil {
-		return req.RemoteAddr
-	}
-	return host
 }


### PR DESCRIPTION
This creates the optional capability to send events to a configurable Scarf endpoint based on channelserver requests.

It can be enabled using the respective commandline arguments.

It is slightly more complex than just creating *every* event to reduce the load a little where that's feasible - the system-upgrade-controller pings every 15 minutes, and by running a small in-memory LRU cache, those approximately get deduplicated to one per replica per day. This cache is not persisted nor shared, since that'd be undue complexity for the impact.

The HyperLogLog dependency is intended to help with tuning this - otherwise, all we'd know is whether the cache is too large or too small, but not by how much.

The memory footprint increases when enabled, but remains bounded.

The impact when Scarf is **not** enabled should be negligible to non-existent.