### PR TITLE
Add support for GitHub App auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ replace k8s.io/client-go => k8s.io/client-go v0.36.0
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/bradleyfalzon/ghinstallation/v2 v2.19.0
 	github.com/google/go-github/v88 v88.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/apiserver v0.9.5
@@ -26,6 +27,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/bradleyfalzon/ghinstallation/v2 v2.19.0 h1:KQfD+43pRw9NUJhGycGrFr9vF1MubZacksKol1gomFI=
+github.com/bradleyfalzon/ghinstallation/v2 v2.19.0/go.mod h1:fe5ECIhCdEnxwLiBlNTxx9CP455wt42BELnlDVMvaAA=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
@@ -19,6 +21,8 @@ github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ var (
 	ListenAddress        string
 	AppName              string
 	GithubToken          string
+	GithubApp            config.GithubApp
 	URLs                 cli.StringSlice
 	SubKeys              cli.StringSlice
 	PathPrefix           cli.StringSlice
@@ -91,8 +92,27 @@ func main() {
 		},
 		&cli.StringFlag{
 			Name:        "github-token",
+			Usage:       "GitHub Auth Token; overrides GitHub App flags if set",
 			EnvVars:     []string{"GITHUB_TOKEN"},
 			Destination: &GithubToken,
+		},
+		&cli.Int64Flag{
+			Name:        "github-app-id",
+			Usage:       "Github App ID",
+			EnvVars:     []string{"GITHUB_APP_ID"},
+			Destination: &GithubApp.ID,
+		},
+		&cli.StringFlag{
+			Name:        "github-app-private-key",
+			Usage:       "Github App RSA Private key; accepts path to file or literal PEM encoded PKCS1 or PKCS8 key",
+			EnvVars:     []string{"GITHUB_APP_PRIVATE_KEY"},
+			Destination: &GithubApp.PrivateKey,
+		},
+		&cli.Int64Flag{
+			Name:        "github-app-installation-id",
+			Usage:       "Github App Installation ID",
+			EnvVars:     []string{"GITHUB_APP_INSTALLATION_ID"},
+			Destination: &GithubApp.InstallationID,
 		},
 		&cli.BoolFlag{
 			Name:        "debug",
@@ -113,6 +133,7 @@ func run(c *cli.Context) error {
 		sources []config.Source
 		waiter  wait.Wait
 		err     error
+		auth    config.GithubAuth
 	)
 
 	logrus.SetOutput(os.Stderr)
@@ -130,6 +151,16 @@ func run(c *cli.Context) error {
 		return err
 	}
 
+	if GithubToken != "" {
+		logrus.Info("Using GitHub auth from static token")
+		auth = config.GithubToken(GithubToken)
+	} else if GithubApp.ID != 0 && GithubApp.InstallationID != 0 && GithubApp.PrivateKey != "" {
+		logrus.Infof("Using GitHub auth from AppID %d", GithubApp.ID)
+		auth = GithubApp
+	} else {
+		logrus.Warnf("Using GitHub anonymous auth - may fail to list all releases")
+	}
+
 	if len(SubKeys.Value()) != len(PathPrefix.Value()) {
 		return errors.Errorf("keys-prefix lengths are not equal %s %s %s", PathPrefix.Value(), SubKeys.Value(), ListenAddress)
 	}
@@ -139,7 +170,7 @@ func run(c *cli.Context) error {
 	}
 	for index, subkey := range SubKeys.Value() {
 		prefix := PathPrefix.Value()[index]
-		config := config.NewConfig(ctx, subkey, waiter, ChannelServerVersion, AppName, GithubToken, sources, RefreshFatal)
+		config := config.NewConfig(ctx, subkey, waiter, ChannelServerVersion, AppName, auth, sources, RefreshFatal)
 		configs[prefix] = config
 		logrus.Infof("Serving channels from %v with subkey %q at /%s", sources, subkey, prefix)
 	}

--- a/pkg/config/auth.go
+++ b/pkg/config/auth.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/bradleyfalzon/ghinstallation/v2"
+	"github.com/google/go-github/v88/github"
+	"github.com/sirupsen/logrus"
+)
+
+type GithubAuth interface {
+	ClientOptions() ([]github.ClientOptionsFunc, error)
+}
+
+type GithubToken string
+
+func (t GithubToken) ClientOptions() ([]github.ClientOptionsFunc, error) {
+	return []github.ClientOptionsFunc{
+		github.WithAuthToken(string(t)),
+	}, nil
+}
+
+type GithubApp struct {
+	ID             int64
+	InstallationID int64
+	PrivateKey     string
+}
+
+func (a GithubApp) ClientOptions() ([]github.ClientOptionsFunc, error) {
+	var transport http.RoundTripper
+	var err error
+	if _, serr := os.Stat(a.PrivateKey); serr == nil {
+		logrus.Debugf("Loading GitHub App Private Key from %s", a.PrivateKey)
+		// PrivateKey is path to a file that exists and can be read
+		transport, err = ghinstallation.NewKeyFromFile(httpClient.Transport, a.ID, a.InstallationID, a.PrivateKey)
+	} else {
+		logrus.Debug("Loading GitHub App Private Key from byte value")
+		// Try to load PrivateKey value as literal key bytes
+		transport, err = ghinstallation.New(httpClient.Transport, a.ID, a.InstallationID, []byte(a.PrivateKey))
+	}
+	if err != nil {
+		return nil, err
+	}
+	return []github.ClientOptionsFunc{
+		github.WithHTTPClient(&http.Client{Timeout: httpClient.Timeout, Transport: transport}),
+	}, nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	urls                 []Source
 
 	url               string
-	ghToken           string
+	ghAuth            GithubAuth
 	redirect          *url.URL
 	gh                *github.Client
 	channelsConfig    *model.ChannelsConfig
@@ -46,14 +46,14 @@ func (s StringSource) URL() string {
 	return string(s)
 }
 
-func NewConfig(ctx context.Context, subKey string, wait Wait, channelServerVersion string, appName string, ghToken string, urls []Source, fatal bool) *Config {
+func NewConfig(ctx context.Context, subKey string, wait Wait, channelServerVersion string, appName string, ghAuth GithubAuth, urls []Source, fatal bool) *Config {
 	c := &Config{
 		subKey:               subKey,
 		channelServerVersion: channelServerVersion,
 		appName:              appName,
 		urls:                 urls,
 
-		ghToken:           ghToken,
+		ghAuth:            ghAuth,
 		channelsConfig:    &model.ChannelsConfig{},
 		releasesConfig:    &model.ReleasesConfig{},
 		appDefaultsConfig: &model.AppDefaultsConfig{},
@@ -89,14 +89,14 @@ func NewConfig(ctx context.Context, subKey string, wait Wait, channelServerVersi
 	return c
 }
 
-func NewConfigNoLoad(ctx context.Context, subKey string, channelServerVersion string, appName string, ghToken string, urls []Source) *Config {
+func NewConfigNoLoad(ctx context.Context, subKey string, channelServerVersion string, appName string, ghAuth GithubAuth, urls []Source) *Config {
 	c := &Config{
 		subKey:               subKey,
 		channelServerVersion: channelServerVersion,
 		appName:              appName,
 		urls:                 urls,
 
-		ghToken:           ghToken,
+		ghAuth:            ghAuth,
 		channelsConfig:    &model.ChannelsConfig{},
 		releasesConfig:    &model.ReleasesConfig{},
 		appDefaultsConfig: &model.AppDefaultsConfig{},
@@ -150,8 +150,12 @@ func (c *Config) ghClient(config *model.ChannelsConfig) (*github.Client, error) 
 	}
 	if c.gh == nil || c.url != config.GitHub.APIURL {
 		opts := []github.ClientOptionsFunc{github.WithHTTPClient(httpClient)}
-		if c.ghToken != "" {
-			opts = append(opts, github.WithAuthToken(c.ghToken))
+		if c.ghAuth != nil {
+			authOpts, err := c.ghAuth.ClientOptions()
+			if err != nil {
+				return nil, err
+			}
+			opts = append(opts, authOpts...)
 		}
 		if config.GitHub.APIURL != "" {
 			opts = append(opts, github.WithEnterpriseURLs(config.GitHub.APIURL, config.GitHub.APIURL))


### PR DESCRIPTION
Allows passing appID, installationID, and RSA private key so that app can refresh its token automatically, instead of using a static token from CLI or env - which cannot be rotated without restarting the process.

Ref: https://pkg.go.dev/github.com/google/go-github/v88/github#hdr-Authentication
> GitHub Apps authentication can be provided by the https://github.com/bradleyfalzon/ghinstallation package. It supports both authentication as an installation, using an installation access token, and as an app, using a JWT. 


Testing:
```console
brandond@dev01:~/go/src/github.com/rancher/channelserver$ go run main.go --config-key k3s --github-app-id 4203365 --github-app-installation-id 144050283 --github-app-private-key privatekey.pem --debug
INFO[0000] Using GitHub auth from AppID 4203365
INFO[0000] Loading configuration from [channels.yaml]
DEBU[0000] Loading GitHub App Private Key from privatekey.pem
DEBU[0000] Making request: POST https://api.github.com/app/installations/144050283/access_tokens
DEBU[0000] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?per_page=100
DEBU[0001] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=2&per_page=100
DEBU[0002] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=3&per_page=100
DEBU[0004] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=4&per_page=100
DEBU[0005] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=5&per_page=100
DEBU[0006] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=6&per_page=100
DEBU[0007] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=7&per_page=100
DEBU[0008] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=8&per_page=100
DEBU[0009] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=9&per_page=100
DEBU[0010] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=10&per_page=100
DEBU[0011] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=11&per_page=100
INFO[0011] Loaded initial configuration for subkey "k3s"
INFO[0011] Serving channels from [channels.yaml] with subkey "k3s" at /v1-release
```

```console
brandond@dev01:~/go/src/github.com/rancher/channelserver$ go run main.go --config-key k3s --github-app-id 4203365 --github-app-installation-id 144050283 --github-app-private-key "$(cat privatekey.pem)" --debug
INFO[0000] Using GitHub auth from AppID 4203365
INFO[0000] Loading configuration from [channels.yaml]
DEBU[0000] Loading GitHub App Private Key from byte value
DEBU[0000] Making request: POST https://api.github.com/app/installations/144050283/access_tokens
DEBU[0000] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?per_page=100
DEBU[0001] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=2&per_page=100
DEBU[0002] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=3&per_page=100
DEBU[0003] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=4&per_page=100
DEBU[0005] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=5&per_page=100
DEBU[0006] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=6&per_page=100
DEBU[0008] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=7&per_page=100
DEBU[0009] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=8&per_page=100
DEBU[0010] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=9&per_page=100
DEBU[0011] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=10&per_page=100
DEBU[0012] Making request: GET https://api.github.com/repos/k3s-io/k3s/releases?page=11&per_page=100
INFO[0012] Loaded initial configuration for subkey "k3s"
INFO[0012] Serving channels from [channels.yaml] with subkey "k3s" at /v1-release
```